### PR TITLE
odb-scripts: publish recent cleanups

### DIFF
--- a/Epic/backup/3rd-party-backup-references/veeam.sh.txt
+++ b/Epic/backup/3rd-party-backup-references/veeam.sh.txt
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+
+set -ex
+
+#------------------------------------------------------------------------------
+
+# Copyright (c) 2023 Nutanix Inc. All rights reserved.
+#
+# Maintainer:   Jon Kohler (jon@nutanix.com)
+# Contributors: Scott Fadden
+#               Charles Sharp
+
+#------------------------------------------------------------------------------
+
+## About
+# This is a sample script for kicking off a Veeam backup job, using Veeam EM's
+# REST API. The intended usage would be at the very end of the "example" ODB
+# backup script, such that after the clones are successfully mounted, a job
+# is queued up to run a file system backup from Veeam.
+
+# Endpoint URL for login action
+veeamUsername="EMUsername" # If using domain based account, enter UPN (e.g. user@domain.com)
+veeamPassword="EMPassword"
+veeamAuth=$(echo -ne "$veeamUsername:$veeamPassword" | base64);
+veeamRestServer="EMServer" #IP Address or FQDN of Enterprise Manager server
+veeamRestPort="9398"
+veeamSessionId=$(curl -X POST "https://urldefense.proofpoint.com/v2/url?u=https-3A__-24veeamRestServer-3A-24veeamRestPort_api_sessionMngr_-3Fv-3Dlatest&d=DwIGaQ&c=s883GpUCOChKOHiocYtGcg&r=NGPRGGo37mQiSXgHKm5rCQ&m=IjcOYjJJ1oHyM4upMR7wUN9ZzfI77-WNoaPWHeY0bro4rutwwViyJmBFTFnsmqV-&s=36GxUaHu0153-XrTQfWo-fKGCG4IajotneHn2KZfC9g&e= " -H "Authorization:Basic $veeamAuth" -H "Content-Length: 0" -H "Accept: application/json" -k -v | awk 'NR==1{sub(/^\xef\xbb\xbf/,"")}1' | jq --raw-output ".SessionId")
+veeamXRestSvcSessionId=$(echo -ne "$veeamSessionId" | base64);
+veeamJobId="763797f3-391c-46c8-aa81-83d04f534396"
+
+# Query Job
+veeamEMJobUrl="https://urldefense.proofpoint.com/v2/url?u=https-3A__-24veeamRestServer-3A-24veeamRestPort_api_nas_jobs_-24veeamJobId-3Fformat-3DEntity&d=DwIGaQ&c=s883GpUCOChKOHiocYtGcg&r=NGPRGGo37mQiSXgHKm5rCQ&m=IjcOYjJJ1oHyM4upMR7wUN9ZzfI77-WNoaPWHeY0bro4rutwwViyJmBFTFnsmqV-&s=71SvQQJ0lNYM1bQbPlxmFTG3IOFjNMrbPs97ztlpURg&e= "
+veeamEMJobDetailUrl=$(curl -X GET "$veeamEMJobUrl" -H "Accept:application/json" -H "X-RestSvcSessionId: $veeamXRestSvcSessionId" -H "Cookie: X-RestSvcSessionId=$veeamXRestSvcSessionId" -H "Content-Length: 0" -k -v | awk 'NR==1{sub(/^\xef\xbb\xbf/,"")}1')
+
+# Start Job
+veeamEMStartUrl="https://urldefense.proofpoint.com/v2/url?u=https-3A__-24veeamRestServer-3A-24veeamRestPort_api_nas_jobs_-24veeamJobId_start&d=DwIGaQ&c=s883GpUCOChKOHiocYtGcg&r=NGPRGGo37mQiSXgHKm5rCQ&m=IjcOYjJJ1oHyM4upMR7wUN9ZzfI77-WNoaPWHeY0bro4rutwwViyJmBFTFnsmqV-&s=_QapUxC6KxbHS1teM8YypJRX8ZURLqdgW6Tgop3ViYo&e= "
+veeamEMResultUrl=$(curl -X POST "$veeamEMStartUrl" -H "Accept:application/json" -H "X-RestSvcSessionId: $veeamXRestSvcSessionId" -H "Cookie: X-RestSvcSessionId=$veeamXRestSvcSessionId" -H "Content-Length: 0" -k -v | awk 'NR==1{sub(/^\xef\xbb\xbf/,"")}1')
+
+# Capture & Display Results
+veeamJobName=$(echo "$veeamEMJobDetailUrl" | jq --raw-output ".Name")
+veeamTaskId=$(echo "$veeamEMResultUrl" | jq --raw-output ".TaskId")
+veeamState=$(echo "$veeamEMResultUrl" | jq --raw-output ".State")
+veeamOperation=$(echo "$veeamEMResultUrl" | jq --raw-output ".Operation")

--- a/Epic/backup/original_example.bash
+++ b/Epic/backup/original_example.bash
@@ -4,11 +4,12 @@ set -ex
 
 #------------------------------------------------------------------------------
 
-# Copyright (c) 2021 Nutanix Inc. All rights reserved.
+# Copyright (c) 2023 Nutanix Inc. All rights reserved.
 #
-# Owner:   epic@nutanix.com
-# Authors: scott.fadden@nutanix.com
-#          jon@nutanix.com
+# Maintainer:   Jon Kohler (jon@nutanix.com)
+# Contributors: Scott Fadden
+#               Charles Sharp
+#               Kyle Anderson
 
 #------------------------------------------------------------------------------
 
@@ -21,13 +22,13 @@ set -ex
 # backups in a production Epic ODB implementation. Modifications will be
 # required to "personalize" this script to the target environment.
 #
-# This script is designed to run within a CentOS/Redhat VM that does *not*
-# run Epic ODB itself, but rather acts as an "utility" VM to both schedule
-# the execution of this script as well as act as the "backup target" for
-# your chosen 3rd party backup software.
+# This script is designed to run within a RHEL VM that does *not* run Epic
+# ODB itself, but rather acts as an "utility" VM to both schedule the execution
+# of this script as well as act as the "backup target" for your chosen 3rd
+# party backup software.
 #
-# This "utility" VM needs to be run in the same AHV cluster as the Epic ODB
-# instances to be backed up, so that we can mount the volume groups in a
+# This "utility" VM must to be run in the same AHV cluster as the Epic ODB
+# instances to be backed up, so that we can mount the volume group(s) in a
 # hot-add manner.
 #
 # The script is designed to handle a single Epic environment at a time, such
@@ -44,7 +45,6 @@ set -ex
 # - Thaw target IRIS instance
 # - Mount VG clone to a "mount" VM
 # - Kick off backup job in 3rd party out-of-system backup provider
-#   - e.g. Veeam
 
 #------------------------------------------------------------------------------
 
@@ -54,50 +54,74 @@ set -ex
 #    the target VG.
 # 2. Add freeze and thaw commands for the target Epic environment.
 # 3. Customize Environment Configuration Variables.
-# 4. Add 3rd party backup command(s).
+# 4. Add 3rd party backup command(s) and configure scheduling (e.g. crontab).
+#      Note: You may wish to do the scheduling FROM the backup software itself.
+#      In that case, skip this step and just use this script as a "pre-backup"
+#      script that gets called as part of the backup job itself.
+
+#------------------------------------------------------------------------------
+
+# Environment Bootstrap Instructions
+# 1. Setup AHV-MOUNT-VM as a RHEL8 or higher release.
+# 2. Ensure SSH key exists on AHV-MOUNT-VM
+#      Usually done with ssh-keygen
+# 3. Ensure passwordless SSH setup between AHV-MOUNT-VM and TARGET_ODB_IP
+#      Usually done with ssh-copyid
+# 4. Add SSH public key to Nutanix cluster using the "lockdown mode" feature
+#      Note: This does not require to set up "Full" lockdown mode, unless that
+#      feature is desired by your organization
+# 5. On AHV-MOUNT-VM, ensure dmidecode package is installed
+#      RHEL8+: dnf install dmidecode
+# 6. For persistency of MP[0] mount point over reboots, you can configure the
+#    mount point in fstab; however, that is not required as the script will
+#    simply remount it every time a new run is kicked off.
+#      Note: If you do decide to use fstab, ensure that the "nofail" mount
+#      option is used, so that if for whatever reason that volume is detached
+#      and then AHV-MOUNT-VM is rebooted, it will avoid going into emergency
+#      mode shell.
 
 #------------------------------------------------------------------------------
 
 ## Environment Configuration Variables
-# Configure these parameters to match the target environment
+# Configure these parameters to match the target environment. These are one time
+# customizations for this script for any given environment
 
 # Target ODB VM Details
 # - This would be a VM on the same cluster as the AHV_MOUNT_VM
 # - This is used to reach into that VM and do the freeze/thaw commands
-TARGET_ODB_IP="10.20.30.40"
+TARGET_ODB_IP="a.b.c.d"
 TARGET_ODB_ACCT="epicadm"
-TARGET_ODB_ENV[0]="poc"
+TARGET_ODB_ENV[0]="prd"
 
 # Nutanix AOS Cluster Details
 # - Use the IP of any AOS CVM (controller VM) in the target cluster
 CVM_ACCT="nutanix"
-CVM_IP="10.20.30.50"
+CVM_IP="a.b.c.d"
 
 # Utility/Mount VM Details
 # - This is the VM in AHV that will mount the disk clones
-AHV_MOUNT_VM="epic-odb-utility1"
+# - This variable needs to be the exact name of the VM as it is listed in
+#   Nutanix Prism.
+AHV_MOUNT_VM="MOUNT-VM-NAME-HERE"
 
 # Nutanix Volume Group (VG) name
 # - This script assumes there is a single data volume group per backup
 # - This VG may contain many individual vdisks and this script assumes that all
 #   disk(s) within the Nutanix-side volume group are aggregated into
 #   a Linux LVM2 volume group.
-# NTNX_SOURCE_VG[0]="epic-data-vg-name-here"
+NTNX_SOURCE_VG[0]="EPIC-DATA-VG-NAME-HERE"
 
-# Nutanix vDisk (if not using VG's)
-# - Some environments may choose to not use a Nutanix VG, e.g. TST / POC, in
-#   which case a single vdisk, with a Linux LVM2 layered on top, is used.
-#   The internal mechanics in AHV are slightly different in this case, so
-#   instead of cloning a volume group, we'll have to clone the individual
-#   disk itself. Avoid this if you can, as it works fine, but makes this
-#   process much more opaque :).
-VMDISK_UUID[0]="58e2606a-055c-40da-9f71-58cf55957936"
 
 # Linux LVM Volume Group name
+# - This is the name as listed in Linux "vgs" output.
 LVM_VG[0]="prdvg"
 
 # Mount point for volume group
-MP[0]="/mnt/backup-nfs/${TARGET_ODB_ENV[0]}"
+# - This is the directory that the Linux LVM2 will be mounted on. This can be
+#   different than how it is mounted within the ODB instance itself, and would
+#   be the directory where you point the backup software to stream the data
+#   from.
+MP[0]="/mnt/backups/folder-name-here"
 
 # Number of clones to keep
 # - This is useful to keep a couple of the recent clones on the system, such
@@ -110,7 +134,7 @@ NUM_KEEP=2
 
 #------------------------------------------------------------------------------
 
-## Script Helpers
+## Internal script variables and helpers
 
 PREFIX_DATE=`date +%s`
 ACLI="/usr/local/nutanix/bin/acli"
@@ -129,25 +153,42 @@ getmyvmname () {
   vmname=`ssh ${CVM_ACCT}@${CVM_IP} "${ACLI} vm.list | grep ${1} " 2> /dev/null | awk '{ print $1}'`
   echo $vmname
 }
+
 myvmid=$(getmyvmid)
 myvmname=$(getmyvmname $myvmid)
-echo "This VM name is " $myvmname " vm_uuid "  $myvmid
+echo "This VM name is " $myvmname " vm_uuid " $myvmid
 
 #------------------------------------------------------------------------------
 
-## Step 1: Check for old clones and remove any over NUM_KEEP
-# Clone order is based on EPOCH timestamp name prefix
+## BEGIN SCRIPT OPERATIONS
+echo "STEP 1: Cleanup environment"
+# - Check for old clones and remove any over NUM_KEEP
+# - Clone order is based on EPOCH timestamp name prefix
 
 # Unmount cloned file system
-umount ${MP[0]}
-vgremove ${LVM_VG[0]} -y
+# - Note: We pipe these to || true because on the very first run or a run where
+#   the mount was previously detached separately, this would fail as the script
+#   as we have set -ex configured.
+echo "Unmount previous volumes and remove VG from LVM database"
+umount ${MP[0]} || true
+vgremove ${LVM_VG[0]} -y || true
+
+# Get the list of block devices excluding /dev/sda and sr0 cd rom drive
+# - Note: We also pipe this to || true as it would otherwise fail if the mount
+#   was previously detached (or otherwise not present).
+devices=$(lsblk -ndo NAME | grep -v sda | grep -v sr0) || true
+
+# Add LVM devices dynamically
+for device in $devices; do
+  lvmdevices -y --deldev "/dev/$device"
+done
 
 # Detach existing clones from VM
-echo "Detach previous clone"
+echo "Detach previous clone(s), if already attached"
 for i in `ssh ${CVM_ACCT}@${CVM_IP} "${ACLI} vg.list | grep 'copy-${TARGET_ODB_ENV[0]}' | awk '{ print $1 }'" 2> /dev/null`
 do
   cnt=`ssh ${CVM_ACCT}@${CVM_IP} "${ACLI} vg.get ${i} | grep 'vm_uuid:.*${myvmid}' | wc -l " 2> /dev/null`
-  #echo "Count for " $i " is " $cnt
+  echo "Count for " $i " is " $cnt
   if (( cnt > 0 )); then
       ret=`ssh ${CVM_ACCT}@${CVM_IP} "${ACLI} vg.detach_from_vm ${i} ${myvmname} " 2> /dev/null`
       echo "Detached clone " ${i} " Ret = " $ret
@@ -169,29 +210,15 @@ done
 
 #------------------------------------------------------------------------------
 
-## Step 2: Freeze target ODB
+echo "STEP 2: Freeze target ODB"
 ssh ${TARGET_ODB_ACCT}@${TARGET_ODB_IP} "echo -n "Freezing ${TARGET_ODB_ENV[0]}: " ; /epic/${TARGET_ODB_ENV[0]}/bin/instfreeze"
 echo ""
 
 #------------------------------------------------------------------------------
 
 ## Step 3: Clone the VG
-# echo "Creating new clone " ${PREFIX_DATE}-copy-${TARGET_ODB_ENV[0]}
-# ssh ${CVM_ACCT}@${CVM_IP} ${ACLI} vg.clone ${PREFIX_DATE}-copy-${TARGET_ODB_ENV[0]} clone_from_vg=${NTNX_SOURCE_VG[0]}
-
-# Special Case: single vDisk (non-VG) cloning
-# - We'll clone the vdisk attached to the environment into a VG, which
-#   allows us to treat the rest of the logic in this script just like we would
-#   if the original setup was with a VG.
-# - To do this, create a tmp volumegroup first, then clone the vdisk into that
-#   temp vg. This will be used to hold the vmdisk clones.
-# - Note: this is here for special cases only, try to avoid this if you can
-#   and use VG's everywhere instead, even for single vdisks in TST, POC, etc.
-ssh ${CVM_ACCT}@${CVM_IP} "${ACLI} vg.create \
-  ${PREFIX_DATE}-copy-${TARGET_ODB_ENV[0]}"
-ssh ${CVM_ACCT}@${CVM_IP} "${ACLI} vg.disk_create \
-  ${PREFIX_DATE}-copy-${TARGET_ODB_ENV[0]} \
-  clone_from_vmdisk=${VMDISK_UUID[0]}"
+echo "Creating new clone " ${PREFIX_DATE}-copy-${TARGET_ODB_ENV[0]}
+ssh ${CVM_ACCT}@${CVM_IP} ${ACLI} vg.clone ${PREFIX_DATE}-copy-${TARGET_ODB_ENV[0]} clone_from_vg=${NTNX_SOURCE_VG[0]}
 
 #------------------------------------------------------------------------------
 
@@ -209,6 +236,17 @@ ssh ${CVM_ACCT}@${CVM_IP} "${ACLI} vg.attach_to_vm ${PREFIX_DATE}-copy-${TARGET_
 # Clean up LVM metadata
 pvscan --cache
 
+# Get the list of block devices excluding /dev/sda
+devices=$(lsblk -ndo NAME | grep -v "sda" | grep -v sr0)
+
+# Add LVM devices dynamically
+for device in $devices; do
+  lvmdevices -y --adddev "/dev/$device"
+done
+
+# Activate all availible LVM Volumes
+vgchange -ay
+
 # Get device name
 dev_path=`/usr/sbin/lvdisplay ${LVM_VG[0]} | awk '{ if( $2 == "Path" ) print $3 }'`
 
@@ -225,36 +263,23 @@ fi
 
 #------------------------------------------------------------------------------
 
-## Step 6: Kick off 3rd party out-of-system backup
-echo "Kick off backup for " ${PREFIX_DATE}-copy-${TARGET_ODB_ENV[0]]}
+echo "STEP 6: Kick off 3rd party out-of-system backup"
+echo "Kick off backup for " ${PREFIX_DATE}-copy-${TARGET_ODB_ENV[0]}
 
-# Endpoint URL for login action
-veeamUsername="EMUsername" # If using domain based account, enter UPN (e.g. user@domain.com)
-veeamPassword="EMPassword"
-veeamAuth=$(echo -ne "$veeamUsername:$veeamPassword" | base64);
-veeamRestServer="EMServer" #IP Address or FQDN of Enterprise Manager server
-veeamRestPort="9398"
-veeamSessionId=$(curl -X POST "https://$veeamRestServer:$veeamRestPort/api/sessionMngr/?v=latest" -H "Authorization:Basic $veeamAuth" -H "Content-Length: 0" -H "Accept: application/json" -k -v | awk 'NR==1{sub(/^\xef\xbb\xbf/,"")}1' | jq --raw-output ".SessionId")
-veeamXRestSvcSessionId=$(echo -ne "$veeamSessionId" | base64);
-veeamJobId="763797f3-391c-46c8-aa81-83d04f534396"
+# Note: See reference scripts directory for sample scripts that can be copy
+# and pasted into this section of the script. The intended use is that once the
+# clone is properly mounted on AHV-MOUNT-VM, the backup job needs to be queued
+# up, so that the 3rd party backup system runs a file system backup to stream
+# the contents of MP[0] mount directory to backup storage.
 
-# Query Job
-veeamEMJobUrl="https://$veeamRestServer:$veeamRestPort/api/nas/jobs/$veeamJobId?format=Entity"
-veeamEMJobDetailUrl=$(curl -X GET "$veeamEMJobUrl" -H "Accept:application/json" -H "X-RestSvcSessionId: $veeamXRestSvcSessionId" -H "Cookie: X-RestSvcSessionId=$veeamXRestSvcSessionId" -H "Content-Length: 0" -k -v | awk 'NR==1{sub(/^\xef\xbb\xbf/,"")}1')
-
-# Start Job
-veeamEMStartUrl="https://$veeamRestServer:$veeamRestPort/api/nas/jobs/$veeamJobId/start"
-veeamEMResultUrl=$(curl -X POST "$veeamEMStartUrl" -H "Accept:application/json" -H "X-RestSvcSessionId: $veeamXRestSvcSessionId" -H "Cookie: X-RestSvcSessionId=$veeamXRestSvcSessionId" -H "Content-Length: 0" -k -v | awk 'NR==1{sub(/^\xef\xbb\xbf/,"")}1')
-
-# Capture & Display Results
-veeamJobName=$(echo "$veeamEMJobDetailUrl" | jq --raw-output ".Name")
-veeamTaskId=$(echo "$veeamEMResultUrl" | jq --raw-output ".TaskId")
-veeamState=$(echo "$veeamEMResultUrl" | jq --raw-output ".State")
-veeamOperation=$(echo "$veeamEMResultUrl" | jq --raw-output ".Operation")
+# Note: Alternatively, you can use this example script as a "pre-backup" script
+# from the 3rd party backup system, which most/all vendors have the ability to
+# do. This would then replace the need to schedule this with Linux crontab,
+# such that the backup software would schedule and control the execution of all
+# jobs.
 
 #------------------------------------------------------------------------------
 
 # TODOs
-# - squash Scott's reg_with_cvm and reg_with_uvm functions to automatically
-#   handle getting passwordless SSH setup.
-# - add error handling
+# - Make runtime variables script inputs (script.sh $1 $2 $3) to avoid customization
+# - Expand error handling


### PR DESCRIPTION
- Cleanup original_example.bash, which includes comments, notes, and polish throughout the example code. This also refactors some of the LVM operations to work in Rocky9/RHEL9.
- Move veeam example to its own file.